### PR TITLE
Add configurable ContentFinder library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # projet-scrap
 
 Ce dépôt fournit un petit outil graphique permettant d'obtenir rapidement un
-sélecteur CSS à partir d'un extrait de code HTML.
+sélecteur CSS à partir d'un extrait de code HTML. Une bibliothèque plus
+complète est également disponible pour détecter le bloc de contenu principal
+dans un document.
 
-## Utilisation
+## Utilisation de l'outil graphique
 
 Lancez simplement :
 
@@ -12,6 +14,21 @@ python3 "python css_selector_gui.py"
 ```
 
 Collez le HTML concerné puis cliquez sur **Générer le Sélecteur CSS**.
+
+## Utilisation de la bibliothèque
+
+```python
+from html_content_finder import ContentFinder
+
+html_doc = """<html>...</html>"""
+finder = ContentFinder(html_doc)
+content_element = finder.find_content_element()
+
+if content_element:
+    print("Sélecteur robuste :", finder.get_robust_selector())
+    print("Sélecteur court :", finder.get_short_selector())
+    print("Chemin XPath :", finder.get_xpath())
+```
 
 ### Exemple minimal
 

--- a/html_content_finder/__init__.py
+++ b/html_content_finder/__init__.py
@@ -1,0 +1,3 @@
+"""High-level API for finding main content in HTML documents."""
+from .content_finder import ContentFinder
+__all__ = ["ContentFinder"]

--- a/html_content_finder/content_finder.py
+++ b/html_content_finder/content_finder.py
@@ -1,0 +1,124 @@
+"""Main class implementing content detection logic."""
+from __future__ import annotations
+
+from bs4 import BeautifulSoup
+from bs4.element import Tag
+from typing import Iterable, List, Optional
+
+from .strategies import (
+    DEFAULT_CONTENT_KEYWORDS,
+    GENERIC_CLASSES,
+    INLINE_TAGS,
+    KeywordStrategy,
+    SemanticTagStrategy,
+    DensityStrategy,
+    StructureStrategy,
+    Strategy,
+)
+
+class ContentFinder:
+    """Detects the main content element of an HTML document."""
+
+    def __init__(
+        self,
+        html: str,
+        *,
+        custom_keywords: Optional[Iterable[str]] = None,
+        exclude_selectors: Optional[Iterable[str]] = None,
+    ) -> None:
+        """Initialize the finder.
+
+        Parameters
+        ----------
+        html:
+            The HTML document to analyse.
+        custom_keywords:
+            Additional keywords to prioritise in class or id names.
+        exclude_selectors:
+            CSS selectors for elements to remove before analysis.
+        """
+        self.soup = BeautifulSoup(html, "html.parser")
+        self.keywords = list(DEFAULT_CONTENT_KEYWORDS)
+        if custom_keywords:
+            self.keywords.extend(custom_keywords)
+        self.exclude_selectors = list(exclude_selectors or [])
+        for sel in self.exclude_selectors:
+            for el in self.soup.select(sel):
+                el.extract()
+
+        self._strategies: List[Strategy] = [
+            KeywordStrategy(self.keywords),
+            SemanticTagStrategy(),
+            DensityStrategy(),
+            StructureStrategy(),
+        ]
+        self._content_element: Optional[Tag] = None
+
+    def find_content_element(self) -> Optional[Tag]:
+        """Return the element with the highest score."""
+        best_el: Optional[Tag] = None
+        best_score = float("-inf")
+        for el in self.soup.find_all(True):
+            score = 0.0
+            for strat in self._strategies:
+                score += strat.score(el)
+            if score > best_score:
+                best_score = score
+                best_el = el
+        self._content_element = best_el
+        return best_el
+
+    # -- Selector utilities -------------------------------------------------
+    def _build_selector_chain(self, element: Tag) -> List[str]:
+        chain: List[str] = []
+        el = element
+        while el and el.parent and el.name != "body":
+            if el.name not in INLINE_TAGS:
+                tag = el.name
+                classes = [c for c in el.get("class", []) if c not in GENERIC_CLASSES]
+                if classes:
+                    tag += "." + ".".join(classes)
+                chain.append(tag)
+            parent = el.parent
+            if any(gc in parent.get("class", []) for gc in GENERIC_CLASSES):
+                break
+            el = parent
+        return list(reversed(chain))
+
+    def get_robust_selector(self) -> Optional[str]:
+        """Return a detailed CSS selector for the content element."""
+        if not self._content_element:
+            return None
+        return " ".join(self._build_selector_chain(self._content_element))
+
+    def get_short_selector(self) -> Optional[str]:
+        """Return a short unique selector, using ID when possible."""
+        if not self._content_element:
+            return None
+        el = self._content_element
+        if el.get("id"):
+            return f"#{el.get('id')}"
+        classes = el.get("class", [])
+        if classes:
+            return f"{el.name}." + ".".join(classes)
+        return el.name
+
+    def get_xpath(self) -> Optional[str]:
+        """Return the XPath of the content element."""
+        if not self._content_element:
+            return None
+        path_parts = []
+        el: Optional[Tag] = self._content_element
+        while el is not None and isinstance(el, Tag):
+            parent = el.parent
+            if parent is None:
+                break
+            index = 1
+            for sibling in parent.find_all(el.name, recursive=False):
+                if sibling is el:
+                    break
+                index += 1
+            path_parts.append(f"{el.name}[{index}]")
+            el = parent if parent.name != "[document]" else None
+        return "/" + "/".join(reversed(path_parts))
+

--- a/html_content_finder/strategies.py
+++ b/html_content_finder/strategies.py
@@ -1,0 +1,76 @@
+"""Scoring strategies for detecting the main content element."""
+from __future__ import annotations
+
+from bs4.element import Tag, NavigableString
+
+DEFAULT_CONTENT_KEYWORDS = ["rte", "content", "desc", "description", "prose", "article-body"]
+
+SEMANTIC_POSITIVE = {"article": 5, "main": 5, "section": 2}
+SEMANTIC_NEGATIVE = {"nav": -5, "header": -5, "footer": -5, "aside": -5}
+
+INLINE_TAGS = ["span", "b", "i", "strong", "em", "a"]
+GENERIC_CLASSES = ["tabcontent", "container", "wrapper", "header", "footer", "nav"]
+
+class Strategy:
+    """Base class for scoring strategies."""
+
+    def score(self, element: Tag) -> float:
+        raise NotImplementedError
+
+class KeywordStrategy(Strategy):
+    """Scores elements based on presence of keywords in class or id."""
+
+    def __init__(self, keywords: list[str]):
+        self.keywords = [kw.lower() for kw in keywords]
+
+    def score(self, element: Tag) -> float:
+        score = 0.0
+        classes = " ".join(element.get("class", [])).lower()
+        element_id = (element.get("id") or "").lower()
+        for kw in self.keywords:
+            if kw in classes:
+                score += 5
+                if any(c == kw for c in element.get("class", [])):
+                    score += 3
+            if kw in element_id:
+                score += 5
+                if element_id == kw:
+                    score += 3
+        return score
+
+class SemanticTagStrategy(Strategy):
+    """Scores semantic HTML5 tags positively or negatively."""
+
+    def score(self, element: Tag) -> float:
+        score = 0.0
+        score += SEMANTIC_POSITIVE.get(element.name, 0)
+        score += SEMANTIC_NEGATIVE.get(element.name, 0)
+        return score
+
+class DensityStrategy(Strategy):
+    """Scores elements based on text density."""
+
+    def score(self, element: Tag) -> float:
+        text_parts = []
+        for child in element.children:
+            if isinstance(child, NavigableString):
+                text_parts.append(str(child))
+        direct_text = "".join(text_parts).strip()
+        if not direct_text:
+            return 0.0
+        html_length = len(str(element))
+        ratio = len(direct_text) / html_length if html_length else 0
+        return ratio * 10
+
+class StructureStrategy(Strategy):
+    """Penalises elements that mostly contain navigation or form elements."""
+
+    NAV_FORM_TAGS = {"a", "input", "button", "select", "option", "form"}
+
+    def score(self, element: Tag) -> float:
+        child_tags = [child.name for child in element.find_all(True, recursive=False)]
+        if not child_tags:
+            return 0.0
+        nav_count = sum(1 for t in child_tags if t in self.NAV_FORM_TAGS)
+        ratio = nav_count / len(child_tags)
+        return -ratio * 10


### PR DESCRIPTION
## Summary
- add html_content_finder package with a `ContentFinder` class
- implement pluggable scoring strategies for element detection
- document library usage in README

## Testing
- `python3 -m py_compile html_content_finder/*.py 'python css_selector_gui.py'`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849d478a4d48330b5c2cfcb88eb3e98