### PR TITLE
Connecte ContentFinder à l'outil graphique

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ python3 "python css_selector_gui.py"
 ```
 
 Collez le HTML concerné puis cliquez sur **Générer le Sélecteur CSS**.
+L'outil utilise la bibliothèque `html_content_finder` pour identifier
+automatiquement le bloc de contenu principal et affiche le sélecteur robuste,
+le sélecteur court et le chemin XPath.
 
 ## Utilisation de la bibliothèque
 

--- a/python css_selector_gui.py
+++ b/python css_selector_gui.py
@@ -2,6 +2,7 @@ from PySide6.QtWidgets import (
     QApplication, QWidget, QVBoxLayout, QTextEdit, QPushButton, QLabel
 )
 from bs4 import BeautifulSoup
+from html_content_finder import ContentFinder
 import sys
 
 # Mots-clés et listes d'exclusions pour le repérage de l'élément pertinent
@@ -100,8 +101,26 @@ class SelectorApp(QWidget):
         html = self.input_box.toPlainText().strip()
         if html:
             try:
-                selector = generate_css_selector_from_html(html)
-                self.result_output.setText(selector)
+                finder = ContentFinder(html)
+                element = finder.find_content_element()
+                if element:
+                    parts = []
+                    robust = finder.get_robust_selector()
+                    if robust:
+                        parts.append(robust)
+                    short = finder.get_short_selector()
+                    if short and short != robust:
+                        parts.append(short)
+                    xpath = finder.get_xpath()
+                    if xpath:
+                        parts.append(xpath)
+                    if parts:
+                        self.result_output.setText("\n".join(parts))
+                    else:
+                        self.result_output.setText("Aucun sélecteur généré.")
+                else:
+                    selector = generate_css_selector_from_html(html)
+                    self.result_output.setText(selector)
             except Exception as e:
                 self.result_output.setText(f"⚠️ Erreur : {str(e)}")
         else:


### PR DESCRIPTION
## Summary
- rely on `html_content_finder.ContentFinder` inside the GUI
- document the new behaviour in README

## Testing
- `python -m py_compile 'python css_selector_gui.py' html_content_finder/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849d669b694833093050d3649097cb3