### PR TITLE
Add interactive selector suggestion mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CSS Selector Generator
 
-This project provides a command-line tool that extracts the most stable CSS selector from an HTML snippet. A small web interface is also included for interactive use.
+This project provides a command-line tool that analyses an HTML snippet and now proposes several CSS selectors ranked by relevance. A small web interface is also included for interactive use.
 
 ## Requirements
 
@@ -16,13 +16,15 @@ pip install -r requirements.txt
 
 ## Command Line Usage
 
-Generate a selector from a file:
+Generate selector suggestions from a file:
 
 ```bash
 python css_selector_generator.py path/to/file.html
 ```
 
-If no file is provided, HTML is read from standard input.
+If no file is provided, HTML is read from standard input. The script then
+prints several CSS selectors with short explanations and highlights the
+recommended one.
 
 ## Web Interface
 

--- a/css_selector_generator.py
+++ b/css_selector_generator.py
@@ -113,6 +113,105 @@ def build_selector(elem) -> str:
     parts.reverse()
     return ' '.join(parts)
 
+def generate_selector_candidates(tag) -> list:
+    """Return a list of possible CSS selectors for the given element."""
+    if tag is None:
+        return []
+
+    candidates = []
+
+    classes = tag.get('class', []) or []
+    parent = tag.parent
+
+    parent_sel = ''
+    if parent and parent.name != '[document]':
+        parent_sel = build_selector(parent)
+
+    # 1. Parent context with tag only
+    if parent_sel:
+        candidates.append(f"{parent_sel} {tag.name}")
+    else:
+        candidates.append(tag.name)
+
+    # 2. Parent classes only if available
+    if parent_sel and parent:
+        parent_classes = [c for c in parent.get('class', []) if not is_generic(c)]
+        if parent_classes:
+            pcls = ''.join(f'.{c}' for c in parent_classes)
+            candidates.append(f"{pcls} {tag.name}")
+
+    # 3. Tag with its own classes
+    if classes:
+        candidates.append(tag.name + ''.join(f'.{c}' for c in classes))
+        candidates.append(''.join(f'.{c}' for c in classes))
+
+    # 4. Full path including classes
+    if parent_sel:
+        own = tag.name
+        if classes:
+            own += ''.join(f'.{c}' for c in classes)
+        candidates.append(f"{parent_sel} {own}")
+
+    # 5. id selector when present
+    if has_good_id(tag):
+        candidates.append(f"#{tag['id']}")
+
+    # Deduplicate while preserving order
+    seen = set()
+    unique = []
+    for sel in candidates:
+        if sel and sel not in seen:
+            unique.append(sel)
+            seen.add(sel)
+    return unique
+
+def explain_selector(selector: str) -> str:
+    """Return a short human explanation for a CSS selector."""
+    if selector.startswith('#'):
+        return "Bas\u00e9 sur l'identifiant unique de l'\u00e9l\u00e9ment, tr\u00e8s fiable."
+    if selector.startswith('.') and ' ' not in selector:
+        return "Utilise uniquement la ou les classes : rapide mais peut correspondre \u00e0 plusieurs \u00e9l\u00e9ments."
+    if ' ' in selector:
+        return "Combinaison d'\u00e9l\u00e9ments pour cibler pr\u00e9cis\u00e9ment la structure."
+    return "S\u00e9lecteur simple bas\u00e9 sur la balise et ses classes."
+
+def _score_candidate(selector: str) -> float:
+    """Internal heuristic to score selectors and choose the best."""
+    score = 0.0
+    if selector.startswith('#'):
+        score += 100
+    if selector and selector[0].isalpha():
+        score += 5
+    classes = re.findall(r'\.([\w-]+)', selector)
+    for cls in classes:
+        if is_generic(cls):
+            score -= 8
+        else:
+            score += 2
+    spaces = selector.count(' ')
+    score += spaces  # context is usually good
+    score -= 2 * spaces
+    score -= len(selector) / 10
+    return score
+
+def display_choices(tag) -> None:
+    """Print all selector candidates with explanations and highlight the best."""
+    candidates = generate_selector_candidates(tag)
+    if not candidates:
+        print("Aucun s\u00e9lecteur trouv\u00e9.")
+        return
+
+    # Rank candidates and keep the top three
+    ranked = sorted(candidates, key=_score_candidate, reverse=True)
+    top = ranked[:3]
+    best = top[0]
+
+    print("\U0001F3AF S\u00e9lecteurs propos\u00e9s :\n")
+    for idx, sel in enumerate(top, 1):
+        exp = explain_selector(sel)
+        print(f"{idx}. {sel}\n   \u2192 {exp}\n")
+    print(f"\u2705 Choix recommand\u00e9 : {best}")
+
 def generate_selector(html: str) -> str:
     """Return the best CSS selector for the given HTML snippet."""
     soup = BeautifulSoup(html, 'html.parser')
@@ -138,9 +237,14 @@ def main():
     else:
         html = sys.stdin.read()
 
-    selector = generate_selector(html)
-    if selector:
-        print(selector)
+    soup = BeautifulSoup(html, 'html.parser')
+    target = choose_best_element(soup)
+    if target:
+        target = refine_candidate(target)
+    if target is None:
+        return
+
+    display_choices(target)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
## Summary
- extend selector generator with candidate explanations
- rank candidates with custom heuristic and present top options
- document new interactive behaviour in README

## Testing
- `python -m py_compile css_selector_generator.py detect_selector.py web_interface.py`
- `python css_selector_generator.py sample.html`

------
https://chatgpt.com/codex/tasks/task_e_684ac06e18348330a342a428bc5ce6c6