### PR TITLE
Add local training pipeline and Tkinter UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,49 +1,37 @@
-# CSS Selector Generator
+# Assistant HTML IA
 
-This project provides a command-line tool that analyses an HTML snippet and now proposes several CSS selectors ranked by relevance. A small web interface is also included for interactive use.
+Ce projet propose un petit assistant capable de comprendre des requêtes en langage naturel ("Quel est le titre ?", "Montre-moi l'image", etc.) et d'indiquer quel élément HTML est visé. Un modèle DistilBERT est entraîné localement pour classer les demandes parmi six labels : `titre`, `bouton`, `image`, `prix`, `lien`, `description`.
 
-## Requirements
+## Installation
 
-* Python 3
-* [BeautifulSoup](https://www.crummy.com/software/BeautifulSoup/)
-* [Flask](https://flask.palletsprojects.com/)
-
-Install the dependencies with:
+Installez les dépendances :
 
 ```bash
 pip install -r requirements.txt
 ```
 
-## Command Line Usage
+## Entraîner le modèle
 
-Generate selector suggestions from a file:
-
-```bash
-python css_selector_generator.py path/to/file.html
-```
-
-If no file is provided, HTML is read from standard input. The script then
-prints several CSS selectors with short explanations and highlights the
-recommended one.
-
-## Web Interface
-
-Start the Flask app to use a simple web interface:
+Le dataset se trouve dans `data/intents.jsonl`. Lancez l'entraînement (CPU) :
 
 ```bash
-python web_interface.py
+python src/train_classifier.py
 ```
 
-Open `http://localhost:5000` in your browser, paste HTML into the textbox, and the tool will display the generated selector.
+Le modèle et le tokenizer seront sauvegardés dans `model/trained_model/`.
 
-## Intelligent Detection with DistilBERT
-
-The scripts `cerveau.py` and `detecteur.py` add a lightweight AI layer that
-understands natural language queries and produces a CSS selector automatically.
+## Tester en ligne de commande
 
 ```bash
-python detecteur.py "je veux le lien" page.html
+python src/predictor.py "Montre-moi le prix"
 ```
 
-`detecteur.py` calls `cerveau.py` which loads a DistilBERT zero-shot classifier
-to infer the target (link, title, image, etc.) before generating the selector.
+## Interface graphique
+
+Une interface minimaliste est disponible :
+
+```bash
+python src/interface_gui.py
+```
+
+Entrez une question et cliquez sur **Prédire** : le label prédit s'affichera.

--- a/data/intents.jsonl
+++ b/data/intents.jsonl
@@ -1,0 +1,180 @@
+{"text": "Quel est le titre ?", "label": "titre"}
+{"text": "Donne-moi le titre", "label": "titre"}
+{"text": "Je veux voir le titre", "label": "titre"}
+{"text": "Affiche le titre", "label": "titre"}
+{"text": "Montre le titre de la page", "label": "titre"}
+{"text": "C'est quoi le titre ?", "label": "titre"}
+{"text": "Récupère le titre", "label": "titre"}
+{"text": "Peux-tu me donner le titre", "label": "titre"}
+{"text": "Je cherche le titre", "label": "titre"}
+{"text": "Quel est le nom de l'article ?", "label": "titre"}
+{"text": "Titre de la page ?", "label": "titre"}
+{"text": "Obtenir le titre", "label": "titre"}
+{"text": "Où est le titre", "label": "titre"}
+{"text": "Je veux juste le titre", "label": "titre"}
+{"text": "Montre-moi le titre exact", "label": "titre"}
+{"text": "Affichage du titre s'il te plaît", "label": "titre"}
+{"text": "Trouve le titre", "label": "titre"}
+{"text": "Quel est le titre affiché ?", "label": "titre"}
+{"text": "Titre principal ?", "label": "titre"}
+{"text": "Le titre m'intéresse", "label": "titre"}
+{"text": "Je souhaite connaître le titre", "label": "titre"}
+{"text": "Titre ?", "label": "titre"}
+{"text": "Fournis-moi le titre", "label": "titre"}
+{"text": "J'ai besoin du titre", "label": "titre"}
+{"text": "Titre de cet élément", "label": "titre"}
+{"text": "Quel titre est utilisé ?", "label": "titre"}
+{"text": "Montre le titre principal", "label": "titre"}
+{"text": "Où peut-on lire le titre ?", "label": "titre"}
+{"text": "Titre recherché", "label": "titre"}
+{"text": "Je veux savoir le titre", "label": "titre"}
+{"text": "Clique sur le bouton", "label": "bouton"}
+{"text": "Où se trouve le bouton ?", "label": "bouton"}
+{"text": "Montre-moi le bouton", "label": "bouton"}
+{"text": "Je voudrais le bouton", "label": "bouton"}
+{"text": "Quel bouton dois-je utiliser ?", "label": "bouton"}
+{"text": "Afficher le bouton principal", "label": "bouton"}
+{"text": "Je cherche le bouton d'action", "label": "bouton"}
+{"text": "Trouve le bouton", "label": "bouton"}
+{"text": "Y a-t-il un bouton ?", "label": "bouton"}
+{"text": "Bouton d'envoi ?", "label": "bouton"}
+{"text": "Je veux appuyer sur le bouton", "label": "bouton"}
+{"text": "Le bouton m'intéresse", "label": "bouton"}
+{"text": "Je souhaite voir le bouton", "label": "bouton"}
+{"text": "Quel est le bouton cliquable ?", "label": "bouton"}
+{"text": "Donne-moi le bouton", "label": "bouton"}
+{"text": "Montre le bouton de confirmation", "label": "bouton"}
+{"text": "Où est le bouton envoyer", "label": "bouton"}
+{"text": "Bouton disponible ?", "label": "bouton"}
+{"text": "Je veux le bouton de recherche", "label": "bouton"}
+{"text": "Trouver le bouton s'il te plaît", "label": "bouton"}
+{"text": "Est-ce qu'il y a un bouton ?", "label": "bouton"}
+{"text": "Bouton principal à afficher", "label": "bouton"}
+{"text": "Localise le bouton", "label": "bouton"}
+{"text": "Je souhaite le bouton principal", "label": "bouton"}
+{"text": "Quel bouton existe ?", "label": "bouton"}
+{"text": "Affiche-moi simplement le bouton", "label": "bouton"}
+{"text": "Je voudrais appuyer sur le bouton principal", "label": "bouton"}
+{"text": "Bouton principal ?", "label": "bouton"}
+{"text": "Peux-tu donner le bouton ?", "label": "bouton"}
+{"text": "Je veux cliquer sur le bouton", "label": "bouton"}
+{"text": "Montre-moi l’image", "label": "image"}
+{"text": "Je veux voir l'image", "label": "image"}
+{"text": "Où est l'image ?", "label": "image"}
+{"text": "Affiche l'image principale", "label": "image"}
+{"text": "Je cherche une image", "label": "image"}
+{"text": "Image de l'article ?", "label": "image"}
+{"text": "Donne-moi l'image", "label": "image"}
+{"text": "Je souhaite l'image", "label": "image"}
+{"text": "Trouve l'image", "label": "image"}
+{"text": "Affichage de l'image ?", "label": "image"}
+{"text": "Peux-tu me montrer l'image", "label": "image"}
+{"text": "Image disponible ?", "label": "image"}
+{"text": "Je veux l'image de couverture", "label": "image"}
+{"text": "Localise l'image", "label": "image"}
+{"text": "Montre l'image si possible", "label": "image"}
+{"text": "Je demande l'image", "label": "image"}
+{"text": "Y a-t-il une image ?", "label": "image"}
+{"text": "Je voudrais l'image affichée", "label": "image"}
+{"text": "Quel est l'image principale ?", "label": "image"}
+{"text": "Image mise en avant ?", "label": "image"}
+{"text": "Où se trouve l'image ?", "label": "image"}
+{"text": "Image désirée", "label": "image"}
+{"text": "Afficher l'image maintenant", "label": "image"}
+{"text": "Je recherche l'image", "label": "image"}
+{"text": "Image de la page ?", "label": "image"}
+{"text": "Montre moi juste l'image", "label": "image"}
+{"text": "Donne l'image en question", "label": "image"}
+{"text": "L'image m'intéresse", "label": "image"}
+{"text": "Peux-tu localiser l'image ?", "label": "image"}
+{"text": "Je veux uniquement l'image", "label": "image"}
+{"text": "Combien ça coûte ?", "label": "prix"}
+{"text": "Quel est le prix ?", "label": "prix"}
+{"text": "Je veux connaître le prix", "label": "prix"}
+{"text": "Affiche le prix", "label": "prix"}
+{"text": "Montre-moi le prix", "label": "prix"}
+{"text": "Prix actuel ?", "label": "prix"}
+{"text": "Donne-moi le prix", "label": "prix"}
+{"text": "Quel est le tarif ?", "label": "prix"}
+{"text": "Je cherche le prix", "label": "prix"}
+{"text": "Le prix de l'article ?", "label": "prix"}
+{"text": "Peux-tu indiquer le prix", "label": "prix"}
+{"text": "Prix demandé", "label": "prix"}
+{"text": "Je souhaite le prix exact", "label": "prix"}
+{"text": "Affichage du prix", "label": "prix"}
+{"text": "Combien vaut cet article", "label": "prix"}
+{"text": "Montre le prix s'il te plaît", "label": "prix"}
+{"text": "Où est écrit le prix", "label": "prix"}
+{"text": "Je voudrais voir le prix", "label": "prix"}
+{"text": "Quel prix est affiché ?", "label": "prix"}
+{"text": "Fournis le prix", "label": "prix"}
+{"text": "Le prix m'intéresse", "label": "prix"}
+{"text": "Je veux juste le prix", "label": "prix"}
+{"text": "Tarif demandé ?", "label": "prix"}
+{"text": "Montre le prix final", "label": "prix"}
+{"text": "Prix de vente ?", "label": "prix"}
+{"text": "Où peut-on lire le prix", "label": "prix"}
+{"text": "Affiche-moi le prix exact", "label": "prix"}
+{"text": "Je cherche simplement le prix", "label": "prix"}
+{"text": "Quel est le montant ?", "label": "prix"}
+{"text": "Donne le prix", "label": "prix"}
+{"text": "Je veux le lien", "label": "lien"}
+{"text": "Où est le lien ?", "label": "lien"}
+{"text": "Montre-moi le lien", "label": "lien"}
+{"text": "Donne-moi le lien", "label": "lien"}
+{"text": "Lien disponible ?", "label": "lien"}
+{"text": "Je souhaite obtenir le lien", "label": "lien"}
+{"text": "Quel est le lien ?", "label": "lien"}
+{"text": "Fournis le lien", "label": "lien"}
+{"text": "Je cherche le lien principal", "label": "lien"}
+{"text": "Affiche le lien", "label": "lien"}
+{"text": "Où puis-je cliquer ?", "label": "lien"}
+{"text": "Je souhaite le lien de la page", "label": "lien"}
+{"text": "Montre le lien s'il te plaît", "label": "lien"}
+{"text": "Lien vers le site ?", "label": "lien"}
+{"text": "Je voudrais le lien d'accès", "label": "lien"}
+{"text": "Lien affiché ?", "label": "lien"}
+{"text": "Localise le lien", "label": "lien"}
+{"text": "Je veux récupérer le lien", "label": "lien"}
+{"text": "Quel lien utiliser ?", "label": "lien"}
+{"text": "Le lien m'intéresse", "label": "lien"}
+{"text": "Affichage du lien ?", "label": "lien"}
+{"text": "Peux-tu donner le lien", "label": "lien"}
+{"text": "Je cherche juste le lien", "label": "lien"}
+{"text": "Lien cliquable ?", "label": "lien"}
+{"text": "Où se trouve le lien ?", "label": "lien"}
+{"text": "Je veux le lien principal", "label": "lien"}
+{"text": "Montre le lien de téléchargement", "label": "lien"}
+{"text": "Je voudrais simplement le lien", "label": "lien"}
+{"text": "Fournis-moi le lien exact", "label": "lien"}
+{"text": "Quel est le lien final ?", "label": "lien"}
+{"text": "Donne-moi la description", "label": "description"}
+{"text": "Quelle est la description ?", "label": "description"}
+{"text": "Je veux voir la description", "label": "description"}
+{"text": "Affiche la description", "label": "description"}
+{"text": "Montre la description de l'article", "label": "description"}
+{"text": "Description disponible ?", "label": "description"}
+{"text": "Je souhaite la description", "label": "description"}
+{"text": "Où est la description ?", "label": "description"}
+{"text": "Je cherche la description", "label": "description"}
+{"text": "Peux-tu indiquer la description", "label": "description"}
+{"text": "Affichage de la description", "label": "description"}
+{"text": "Je voudrais la description", "label": "description"}
+{"text": "Description détaillée ?", "label": "description"}
+{"text": "Fournis la description", "label": "description"}
+{"text": "Montre-moi la description complète", "label": "description"}
+{"text": "La description m'intéresse", "label": "description"}
+{"text": "Je veux obtenir la description", "label": "description"}
+{"text": "Où peut-on lire la description", "label": "description"}
+{"text": "Je souhaite voir la description complète", "label": "description"}
+{"text": "Description de cet élément ?", "label": "description"}
+{"text": "Quelle est la description exacte ?", "label": "description"}
+{"text": "Donne la description s'il te plaît", "label": "description"}
+{"text": "Je cherche simplement la description", "label": "description"}
+{"text": "Affiche la description complète", "label": "description"}
+{"text": "Je veux juste la description", "label": "description"}
+{"text": "Peux-tu donner la description ?", "label": "description"}
+{"text": "La description est où ?", "label": "description"}
+{"text": "Montre la description précise", "label": "description"}
+{"text": "Je désire la description", "label": "description"}
+{"text": "Quelle description est fournie ?", "label": "description"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
-torch
 transformers
+datasets
+torch
+scikit-learn
+tk
 beautifulsoup4
 flask

--- a/src/interface_gui.py
+++ b/src/interface_gui.py
@@ -1,0 +1,27 @@
+import tkinter as tk
+from predictor import predict_intent
+
+
+def on_predict():
+    text = entry.get()
+    if not text.strip():
+        result_var.set("")
+        return
+    label = predict_intent(text)
+    result_var.set(label)
+
+
+root = tk.Tk()
+root.title("\U0001F9E0 Intelligence HTML – Assistant IA")
+
+entry = tk.Entry(root, width=50)
+entry.pack(padx=10, pady=10)
+
+button = tk.Button(root, text="Pr\u00e9dire", command=on_predict)
+button.pack(pady=5)
+
+result_var = tk.StringVar()
+result_label = tk.Label(root, textvariable=result_var, font=("Helvetica", 14))
+result_label.pack(pady=10)
+
+root.mainloop()

--- a/src/predictor.py
+++ b/src/predictor.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+
+import torch
+from transformers import AutoModelForSequenceClassification, DistilBertTokenizerFast
+
+MODEL_DIR = Path(__file__).resolve().parents[1] / "model" / "trained_model"
+
+tokenizer = DistilBertTokenizerFast.from_pretrained(MODEL_DIR)
+model = AutoModelForSequenceClassification.from_pretrained(MODEL_DIR)
+model.eval()
+
+id2label = {int(k): v for k, v in model.config.id2label.items()}
+
+
+def predict_intent(text: str) -> str:
+    inputs = tokenizer(text, return_tensors="pt", truncation=True, padding=True)
+    with torch.no_grad():
+        outputs = model(**inputs)
+        pred_id = outputs.logits.argmax(dim=1).item()
+    return id2label[pred_id]
+
+
+if __name__ == "__main__":
+    import sys
+
+    if len(sys.argv) > 1:
+        sentence = " ".join(sys.argv[1:])
+    else:
+        sentence = input("Texte: ")
+    print(predict_intent(sentence))

--- a/src/train_classifier.py
+++ b/src/train_classifier.py
@@ -1,0 +1,69 @@
+import json
+from pathlib import Path
+
+from datasets import load_dataset
+from transformers import (
+    AutoModelForSequenceClassification,
+    DistilBertTokenizerFast,
+    Trainer,
+    TrainingArguments,
+)
+from sklearn.metrics import accuracy_score
+
+
+def main():
+    data_path = Path(__file__).resolve().parents[1] / "data" / "intents.jsonl"
+    dataset = load_dataset("json", data_files=str(data_path))
+    dataset = dataset["train"].train_test_split(test_size=0.2, seed=42)
+
+    labels = sorted(set(dataset["train"]["label"]))
+    label2id = {l: i for i, l in enumerate(labels)}
+    id2label = {i: l for l, i in label2id.items()}
+
+    tokenizer = DistilBertTokenizerFast.from_pretrained("distilbert-base-multilingual-cased")
+
+    def tokenize(batch):
+        enc = tokenizer(batch["text"], truncation=True, padding="max_length", max_length=32)
+        enc["labels"] = [label2id[l] for l in batch["label"]]
+        return enc
+
+    tokenized = dataset.map(tokenize, batched=True)
+
+    model = AutoModelForSequenceClassification.from_pretrained(
+        "distilbert-base-multilingual-cased", num_labels=len(labels), id2label=id2label, label2id=label2id
+    )
+
+    args = TrainingArguments(
+        output_dir=str(Path(__file__).resolve().parents[1] / "model" / "trained_model"),
+        evaluation_strategy="epoch",
+        save_strategy="epoch",
+        num_train_epochs=3,
+        per_device_train_batch_size=8,
+        per_device_eval_batch_size=8,
+        load_best_model_at_end=True,
+        metric_for_best_model="accuracy",
+        logging_dir="logs",
+    )
+
+    def compute_metrics(eval_pred):
+        logits, labels = eval_pred
+        preds = logits.argmax(-1)
+        acc = accuracy_score(labels, preds)
+        return {"accuracy": acc}
+
+    trainer = Trainer(
+        model=model,
+        args=args,
+        train_dataset=tokenized["train"],
+        eval_dataset=tokenized["test"],
+        tokenizer=tokenizer,
+        compute_metrics=compute_metrics,
+    )
+
+    trainer.train()
+    trainer.save_model(args.output_dir)
+    tokenizer.save_pretrained(args.output_dir)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add dataset of intents for local training
- implement `train_classifier.py` to fine-tune DistilBERT
- add `predictor.py` for loading the trained model
- create a Tkinter GUI `interface_gui.py`
- update requirements and README with usage instructions

## Testing
- `python src/train_classifier.py` *(fails: ModuleNotFoundError: No module named 'datasets')*
- `python src/interface_gui.py` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684b2382517c8330aa14e3f7d9ae7198