### PR TITLE
Fix classification for image questions

### DIFF
--- a/intelligence.py
+++ b/intelligence.py
@@ -1,3 +1,5 @@
+"""Analyse d'une question en langage naturel."""
+
 from transformers import pipeline
 
 MODEL_NAME = "distilbert-base-multilingual-cased"
@@ -5,7 +7,23 @@ LABELS = ["titre", "description", "prix", "image", "lien", "bouton"]
 
 _classifier = pipeline("zero-shot-classification", model=MODEL_NAME)
 
+_KEYWORDS = {
+    "titre": ["titre", "title"],
+    "description": ["description"],
+    "prix": ["prix", "price"],
+    "image": ["image", "photo"],
+    "lien": ["lien", "url", "adresse"],
+    "bouton": ["bouton", "button"],
+}
+
+
 def analyser_question(question: str, debug: bool = True) -> str:
+    """Return the most probable label for the question."""
+    q = question.lower()
+    for label, words in _KEYWORDS.items():
+        if any(w in q for w in words):
+            return label
+
     result = _classifier(question, candidate_labels=LABELS)
     label = result["labels"][0]
 


### PR DESCRIPTION
## Summary
- add simple keyword heuristic in `intelligence.py` so questions with obvious words bypass the zero-shot model
- install deps and run tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b29b0b48483308ebe3c6c150cca1c