### PR TITLE
Fix predictor path and input validation

### DIFF
--- a/src/predictor.py
+++ b/src/predictor.py
@@ -1,9 +1,13 @@
+"""Utilities for loading the trained intent classifier and predicting labels."""
+
 from pathlib import Path
 
 import torch
 from transformers import AutoModelForSequenceClassification, DistilBertTokenizerFast
 
-MODEL_DIR = Path(__file__).resolve().parents[1] / "model" / "trained_model"
+MODEL_DIR = Path(__file__).resolve().parent.parent / "model" / "trained_model"
+if not MODEL_DIR.exists():
+    raise FileNotFoundError(f"Trained model directory not found: {MODEL_DIR}")
 
 tokenizer = DistilBertTokenizerFast.from_pretrained(MODEL_DIR)
 model = AutoModelForSequenceClassification.from_pretrained(MODEL_DIR)
@@ -13,6 +17,9 @@ id2label = {int(k): v for k, v in model.config.id2label.items()}
 
 
 def predict_intent(text: str) -> str:
+    text = text.strip()
+    if not text:
+        raise ValueError("Input text is empty")
     inputs = tokenizer(text, return_tensors="pt", truncation=True, padding=True)
     with torch.no_grad():
         outputs = model(**inputs)


### PR DESCRIPTION
## Summary
- add module docstring
- use `parent.parent` to resolve model directory
- raise an error if the model directory is missing
- validate input in `predict_intent`

## Testing
- `pip install torch --index-url https://download.pytorch.org/whl/cpu -q`
- `pip install beautifulsoup4 -q`
- `pip install transformers -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b31df8a788330ac168ad7c4806471