### PR TITLE
Fix label preprocessing in dataset mapping

### DIFF
--- a/src/train_classifier.py
+++ b/src/train_classifier.py
@@ -28,7 +28,7 @@ def main() -> None:
         enc["labels"] = [label2id[l] for l in batch["label"]]
         return enc
 
-    tokenized = dataset.map(tokenize, batched=True)
+    tokenized = dataset.map(tokenize, batched=True, remove_columns=["text", "label"])
 
     model = AutoModelForSequenceClassification.from_pretrained(
         "distilbert-base-multilingual-cased", num_labels=len(labels), id2label=id2label, label2id=label2id


### PR DESCRIPTION
## Summary
- remove original text/label columns when tokenizing

## Testing
- `python -m py_compile src/train_classifier.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bs4')*

------
https://chatgpt.com/codex/tasks/task_e_684b36286bf48330812b78f75f7ad549