### PR TITLE
Implement global interaction logging

### DIFF
--- a/detect_selector.py
+++ b/detect_selector.py
@@ -2,6 +2,7 @@ import sys
 import re
 import argparse
 from typing import List, Tuple
+from src.memoire_generale import ajouter_interaction
 from bs4 import BeautifulSoup
 
 # Inline and structural tags used to weight candidate elements
@@ -206,6 +207,10 @@ def main():
             html = f.read()
     else:
         html = prompt_input()
+    try:
+        ajouter_interaction("texte_libre", {"message": html})
+    except Exception:
+        pass
 
     soup = BeautifulSoup(html, 'html.parser')
     mode = args.mode
@@ -217,6 +222,13 @@ def main():
         target = refine_candidate(target)
         selector = build_selector(target)
         explanation = describe_element(target)
+        try:
+            ajouter_interaction(
+                "prediction",
+                {"html": str(target), "reponse": selector},
+            )
+        except Exception:
+            pass
         print(f"\u2705 S\u00e9lecteur g\u00e9n\u00e9r\u00e9 : {selector}")
         print(f"\U0001F9E0 Explication : {explanation}\n")
 

--- a/detecteur.py
+++ b/detecteur.py
@@ -3,6 +3,7 @@ import argparse
 from bs4 import BeautifulSoup
 from intelligence import analyser_question
 from css_selector_generator import build_selector
+from src.memoire_generale import ajouter_interaction
 
 
 _LABEL_TAGS = {
@@ -31,7 +32,15 @@ def generer_selecteur(html: str, question: str) -> str:
     cible = choisir_meilleur(elements)
     if cible is None:
         return ""
-    return build_selector(cible)
+    selector = build_selector(cible)
+    try:
+        ajouter_interaction(
+            "prediction",
+            {"question": question, "html": html, "reponse": selector},
+        )
+    except Exception:
+        pass
+    return selector
 
 def main():
     parser = argparse.ArgumentParser(
@@ -47,7 +56,13 @@ def main():
     else:
         html = sys.stdin.read()
 
-    selector = generer_selecteur(html, args.question)
+    ajouter_interaction("texte_libre", {"message": args.question})
+    try:
+        selector = generer_selecteur(html, args.question)
+        ajouter_interaction("reponse", {"texte": selector})
+    except Exception as e:
+        ajouter_interaction("erreur", {"exception": str(e)})
+        raise
     print(selector)
 
 if __name__ == "__main__":

--- a/interface_test.py
+++ b/interface_test.py
@@ -1,4 +1,5 @@
 from detecteur import generer_selecteur
+from src.memoire_generale import ajouter_interaction
 
 if __name__ == "__main__":
     print("\U0001F3A7 Interface Test – Analyse de sélecteurs CSS avec IA\n")
@@ -8,7 +9,13 @@ if __name__ == "__main__":
             path = input("\U0001F4C4 Fichier HTML → ")
             with open(path, "r", encoding="utf-8") as f:
                 html = f.read()
-            sel = generer_selecteur(html, q)
+            ajouter_interaction("texte_libre", {"message": q})
+            try:
+                sel = generer_selecteur(html, q)
+                ajouter_interaction("reponse", {"texte": sel})
+            except Exception as e:
+                ajouter_interaction("erreur", {"exception": str(e)})
+                raise
             print(f"\n\U0001F3AF Sélecteur généré : {sel}\n")
     except KeyboardInterrupt:
         print("\n\U0001F44B Interface terminée.")

--- a/src/html_selector.py
+++ b/src/html_selector.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import torch
 from transformers import AutoModelForSequenceClassification, DistilBertTokenizerFast
+from src.memoire_generale import ajouter_interaction
 
 MODEL_DIR = Path(__file__).resolve().parent.parent / "model" / "html_selector"
 if not MODEL_DIR.exists():
@@ -22,4 +23,12 @@ def predire_selecteur(question: str, html: str) -> str:
     with torch.no_grad():
         logits = _model(**inputs).logits
         pred_id = logits.argmax(dim=1).item()
-    return _id2label[pred_id]
+    selector = _id2label[pred_id]
+    try:
+        ajouter_interaction(
+            "prediction",
+            {"question": question, "html": html, "reponse": selector},
+        )
+    except Exception:
+        pass
+    return selector

--- a/src/interface_gui.py
+++ b/src/interface_gui.py
@@ -2,6 +2,7 @@
 
 import tkinter as tk
 from html_selector import predire_selecteur
+from src.memoire_generale import ajouter_interaction
 
 
 def on_predict():
@@ -10,7 +11,17 @@ def on_predict():
     if not question.strip() or not html.strip():
         result_var.set("")
         return
-    selector = predire_selecteur(question, html)
+    ajouter_interaction("texte_libre", {"message": question})
+    try:
+        selector = predire_selecteur(question, html)
+        ajouter_interaction(
+            "prediction",
+            {"question": question, "html": html, "reponse": selector},
+        )
+        ajouter_interaction("reponse", {"texte": selector})
+    except Exception as e:  # pragma: no cover - UI exceptions aren't tested
+        ajouter_interaction("erreur", {"exception": str(e)})
+        selector = ""
     result_var.set(f"\U0001F9E0 Sélecteur prédit : {selector}")
 
 

--- a/src/memoire_generale.py
+++ b/src/memoire_generale.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import List, Dict, Any
+
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+
+
+def ajouter_interaction(type: str, contenu: Dict[str, Any], fichier: str = "data/historique.jsonl") -> None:
+    """Ajoute une interaction dans le fichier JSONL."""
+    entry = {"type": type, "timestamp": datetime.utcnow().isoformat(), "contenu": contenu}
+    path = BASE_DIR / fichier
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as f:
+        json.dump(entry, f, ensure_ascii=False)
+        f.write("\n")
+
+
+def charger_historique(fichier: str = "data/historique.jsonl") -> List[Dict[str, Any]]:
+    """Charge toutes les interactions du fichier JSONL."""
+    path = BASE_DIR / fichier
+    if not path.is_file():
+        return []
+    interactions = []
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                interactions.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    return interactions

--- a/web_interface.py
+++ b/web_interface.py
@@ -1,5 +1,6 @@
 from flask import Flask, request, render_template
 from css_selector_generator import generate_selector
+from src.memoire_generale import ajouter_interaction
 
 app = Flask(__name__)
 
@@ -9,7 +10,14 @@ def index():
     html_snippet = ''
     if request.method == 'POST':
         html_snippet = request.form.get('html', '')
-        selector = generate_selector(html_snippet)
+        ajouter_interaction("texte_libre", {"message": html_snippet})
+        try:
+            selector = generate_selector(html_snippet)
+            ajouter_interaction("prediction", {"html": html_snippet, "reponse": selector})
+            ajouter_interaction("reponse", {"texte": selector})
+        except Exception as e:
+            ajouter_interaction("erreur", {"exception": str(e)})
+            selector = ''
     return render_template('index.html', selector=selector, html=html_snippet)
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- add `memoire_generale.py` module to store and load interactions
- record user questions and results in GUI, CLI and web apps
- log predictions inside selector and intent prediction functions
- hook interaction logging in utility scripts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b4c10257c8330a0bb20654e4e690f