### PR TITLE
Fix ModuleNotFoundError for training scripts

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+"""src package: training and predictor modules."""


### PR DESCRIPTION
## Summary
- mark `src/` as a package so its modules import correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c74a48d5083309461fa2ff99b6d5c