### PR TITLE
Add HTML-only selector model training

### DIFF
--- a/NOTICE_fr.md
+++ b/NOTICE_fr.md
@@ -15,9 +15,11 @@ Ce fichier récapitule rapidement les étapes principales du projet.
     ```bash
     python -m src.train_classifier
     python -m src.train_html_selector_model
+    python -m src.train_html_only_selector_model
     ```
-    (les commandes `python cli.py train-classifier` et
-    `python cli.py train-selector` sont équivalentes)
+    (les commandes `python cli.py train-classifier`,
+    `python cli.py train-selector` et
+    `python cli.py train-selector-html` sont équivalentes)
 
     Les fichiers générés seront sauvegardés dans `model/`.
 

--- a/cli.py
+++ b/cli.py
@@ -24,6 +24,13 @@ def train_selector():
     from src import train_html_selector_model as th
     th.main()
 
+
+@cli.command('train-selector-html')
+def train_selector_html():
+    """Train the HTML-only selector model."""
+    from src import train_html_only_selector_model as thh
+    thh.main()
+
 @cli.command()
 def serve():
     """Run the Flask web interface."""

--- a/config.py
+++ b/config.py
@@ -7,10 +7,12 @@ MODEL_DIR = BASE_DIR / "model"
 # Dataset paths
 INTENTS_FILE = DATA_DIR / "intents.jsonl"
 HTML_SELECTOR_FILE = DATA_DIR / "html_selector_dataset.jsonl"
+HTML_ONLY_SELECTOR_FILE = DATA_DIR / "dataset_with_selector.csv"
 
 # Model directories
 CLASSIFIER_MODEL_DIR = MODEL_DIR / "trained_model"
 HTML_SELECTOR_MODEL_DIR = MODEL_DIR / "html_selector"
+HTML_ONLY_SELECTOR_MODEL_DIR = MODEL_DIR / "html_only_selector"
 
 # Training hyperparameters
 TRAIN_EPOCHS = 5

--- a/src/train_html_only_selector_model.py
+++ b/src/train_html_only_selector_model.py
@@ -1,0 +1,12 @@
+"""CLI entry point for training HTML-only selector model."""
+
+from src import training
+
+
+def main() -> None:
+    """Run the HTML-only selector training."""
+    training.train_html_only_selector()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- support training model that predicts selector from HTML only
- expose new CLI command `train-selector-html`
- document new command in NOTICE

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c86929a088330a5334b9cb154b0d9