### PR TITLE
Add HTML-only selector predictor

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Toutes les actions principales sont accessibles via `cli.py` :
 python cli.py generate         # génère un dataset HTML
 python cli.py train-classifier # entraîne le classifieur
 python cli.py train-selector   # entraîne le modèle de sélecteur
+python cli.py predict-selector-html page.html # prédit le sélecteur
 python cli.py serve            # lance le serveur Flask
 ```
 
@@ -37,6 +38,7 @@ Le modèle et le tokenizer seront sauvegardés dans `model/trained_model/`.
 
 ```bash
 python src/predictor.py "Montre-moi le prix"
+cat page.html | python src/html_only_predictor.py
 ```
 
 ## Interface graphique

--- a/cli.py
+++ b/cli.py
@@ -31,6 +31,21 @@ def train_selector_html():
     from src import train_html_only_selector_model as thh
     thh.main()
 
+
+@cli.command('predict-selector-html')
+@click.argument('file', required=False, type=click.Path())
+def predict_selector_html(file):
+    """Predict CSS selector from a HTML snippet."""
+    from src import html_only_predictor as hp
+    if file:
+        with open(file, 'r', encoding='utf-8') as f:
+            html = f.read()
+    else:
+        import sys
+        html = sys.stdin.read()
+    selector = hp.predict_selector(html)
+    click.echo(selector)
+
 @cli.command()
 def serve():
     """Run the Flask web interface."""

--- a/src/html_only_predictor.py
+++ b/src/html_only_predictor.py
@@ -1,0 +1,73 @@
+"""Prediction utility for HTML-only selector model."""
+
+import argparse
+import sys
+from pathlib import Path
+
+import torch
+from transformers import (
+    AutoModelForSequenceClassification,
+    DistilBertTokenizerFast,
+)
+
+import config
+from src.memoire_generale import ajouter_interaction
+
+MODEL_DIR = config.HTML_ONLY_SELECTOR_MODEL_DIR
+if not MODEL_DIR.exists():
+    raise FileNotFoundError(
+        f"Trained model directory not found: {MODEL_DIR}"
+    )
+
+_tokenizer = DistilBertTokenizerFast.from_pretrained(MODEL_DIR)
+_model = AutoModelForSequenceClassification.from_pretrained(MODEL_DIR)
+_model.eval()
+
+_id2label = {int(k): v for k, v in _model.config.id2label.items()}
+
+
+def predict_selector(html: str) -> str:
+    """Return predicted CSS selector for given HTML snippet."""
+    html = html.strip()
+    if not html:
+        raise ValueError("Input HTML is empty")
+    inputs = _tokenizer(
+        html,
+        return_tensors="pt",
+        truncation=True,
+        padding=True,
+    )
+    with torch.no_grad():
+        logits = _model(**inputs).logits
+        pred_id = logits.argmax(dim=1).item()
+    selector = _id2label[pred_id]
+    try:
+        ajouter_interaction(
+            "prediction",
+            {"html": html, "reponse": selector},
+        )
+    except Exception:
+        pass
+    return selector
+
+
+def main(argv=None) -> None:
+    """Run the predictor from the command line."""
+    parser = argparse.ArgumentParser(
+        description="Predict CSS selector from HTML snippet",
+    )
+    parser.add_argument("file", nargs="?", help="HTML file, default stdin")
+    args = parser.parse_args(argv)
+
+    if args.file:
+        with open(args.file, "r", encoding="utf-8") as f:
+            html = f.read()
+    else:
+        html = sys.stdin.read()
+
+    selector = predict_selector(html)
+    print(selector)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- create `html_only_predictor.py` for predicting a CSS selector from HTML only
- hook the predictor from `cli.py` via `predict-selector-html` command
- document the new command and example usage in the README

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cb0cde1948330a31e75bd5b75d586